### PR TITLE
Nf generar funcionalidad pasarela de pagos

### DIFF
--- a/src/modules/payments/dto/create-payment.dto.ts
+++ b/src/modules/payments/dto/create-payment.dto.ts
@@ -1,11 +1,12 @@
 import { Type } from 'class-transformer';
 import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
 import { User } from 'src/modules/users/entities/user.entity';
+import { SubscriptionStatus } from '../enums/suscriptionStatus.enum';
 
 export class CreatePaymentDto {
   stripeSubscriptionId: string;
 
-  isActive: boolean;
+  status: SubscriptionStatus;
 
   user: User;
 

--- a/src/modules/payments/entities/payment.entity.ts
+++ b/src/modules/payments/entities/payment.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { SubscriptionStatus } from '../enums/suscriptionStatus.enum';
 
 @Entity({ name: 'payments' })
 export class Payment {
@@ -15,8 +16,12 @@ export class Payment {
   @Column()
   stripeSubscriptionId: string;
 
-  @Column({ type: 'boolean' })
-  isActive: boolean;
+  @Column({
+    type: 'enum',
+    enum: SubscriptionStatus,
+    default: SubscriptionStatus.INCOMPLETE,
+  })
+  status: SubscriptionStatus;
 
   @CreateDateColumn({ type: 'timestamptz' })
   created_at: Date;

--- a/src/modules/payments/enums/suscriptionStatus.enum.ts
+++ b/src/modules/payments/enums/suscriptionStatus.enum.ts
@@ -1,0 +1,11 @@
+export enum SubscriptionStatus {
+  TRIALING = 'trialing',
+  ACTIVE = 'active',
+  INCOMPLETE = 'incomplete',
+  INCOMPLETE_EXPIRED = 'incomplete_expired',
+  PAST_DUE = 'past_due',
+  CANCELED = 'canceled',
+  UNPAID = 'unpaid',
+  PAUSED = 'paused',
+  UNEXPECTED = 'unexpected',
+}

--- a/src/modules/payments/payment.repository.ts
+++ b/src/modules/payments/payment.repository.ts
@@ -66,6 +66,8 @@ export class PaymentRepository {
           'user.subscriptionType',
           'user.isActive',
         ])
+        .orderBy('payment.created_at', 'DESC')
+        .addOrderBy('payment.id', 'ASC')
         .skip(skip)
         .take(limit)
         .getManyAndCount();

--- a/src/modules/payments/payment.repository.ts
+++ b/src/modules/payments/payment.repository.ts
@@ -4,6 +4,7 @@ import { Payment } from './entities/payment.entity';
 import { Repository } from 'typeorm';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { UpdatePaymentDto } from './dto/update-payment.dto';
+import { SubscriptionStatus } from './enums/suscriptionStatus.enum';
 
 @Injectable()
 export class PaymentRepository {
@@ -30,7 +31,7 @@ export class PaymentRepository {
     return await this.PaymentRepository.findOne({
       where: {
         user: { id: userId },
-        isActive: true,
+        status: SubscriptionStatus.ACTIVE,
       },
     });
   }
@@ -52,5 +53,22 @@ export class PaymentRepository {
       results,
       total,
     };
+  }
+
+  async findAll(skip: number, limit: number): Promise<[Payment[], number]> {
+    const result: [Payment[], number] =
+      await this.PaymentRepository.createQueryBuilder('payment')
+        .leftJoinAndSelect('payment.user', 'user')
+        .select([
+          'payment',
+          'user.id',
+          'user.name',
+          'user.subscriptionType',
+          'user.isActive',
+        ])
+        .skip(skip)
+        .take(limit)
+        .getManyAndCount();
+    return result;
   }
 }

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -10,6 +10,9 @@ import {
 import { PaymentsService } from './payments.service';
 import { AuthGuard } from '../auth/guards/auth.guard';
 import { GetPaymentDto } from './dto/get-payment.dto';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Role } from '../auth/enums/roles.enum';
+import { Roles } from 'src/decorators/roles.decorator';
 
 @Controller('payments')
 export class PaymentsController {
@@ -32,6 +35,13 @@ export class PaymentsController {
     const limit: number = getPaymentData.limit;
     const page: number = getPaymentData.page;
     return this.paymentsService.getAllPaymentsByUser(userId, limit, page);
+  }
+
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.ADMIN)
+  @Get('all')
+  async getAllPayments(@Query() getPaymentDto: GetPaymentDto) {
+    return this.paymentsService.getAllPayments(getPaymentDto);
   }
 
   @UseGuards(AuthGuard)

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -125,7 +125,7 @@ export class PaymentsService {
         currentPeriodStart: new Date(paymentData.current_period_start * 1000),
         currentPeriodEnd: new Date(paymentData.current_period_end * 1000),
       };
-      await this.paymentRepository.create(createPaymentData);
+      return await this.paymentRepository.create(createPaymentData);
     }
   }
 
@@ -133,7 +133,10 @@ export class PaymentsService {
     const payment: Payment | null =
       await this.paymentRepository.findOneByStripeId(paymentData.id);
     if (!payment) {
-      await this.registerPayment(paymentData);
+      const registerPayment: Payment = await this.registerPayment(paymentData);
+      if (registerPayment.status === SubscriptionStatus.ACTIVE) {
+        await this.userService.updateSubscriptionType(registerPayment.user.id);
+      }
     } else if (payment) {
       const stripeCustomerId: string = paymentData.customer.toString();
       const user: User =

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -130,6 +130,7 @@ export class PaymentsService {
   }
 
   async updatePayment(paymentData: Stripe.Subscription) {
+    console.log(paymentData);
     const payment: Payment | null =
       await this.paymentRepository.findOneByStripeId(paymentData.id);
     console.log(payment);

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -6,6 +6,9 @@ import { UsersService } from '../users/users.service';
 import { User } from '../users/entities/user.entity';
 import { PaymentRepository } from './payment.repository';
 import { Payment } from './entities/payment.entity';
+import { GetPaymentDto } from './dto/get-payment.dto';
+import { SubscriptionStatus } from './enums/suscriptionStatus.enum';
+import { UpdatePaymentDto } from './dto/update-payment.dto';
 
 @Injectable()
 export class PaymentsService {
@@ -76,39 +79,94 @@ export class PaymentsService {
     };
   }
 
+  async getAllPayments(getPaymentDto: GetPaymentDto) {
+    const { page, limit } = getPaymentDto;
+    const skip = (page - 1) * limit;
+    const [result, totalPayments] = await this.paymentRepository.findAll(
+      skip,
+      limit,
+    );
+    const totalPages: number = Math.ceil(totalPayments / limit);
+
+    return {
+      message: 'Registros de pagos obtenidos exitosamente',
+      data: result,
+      pagination: {
+        page,
+        limit,
+        totalPayments,
+        totalPages,
+      },
+    };
+  }
+
   async registerPayment(paymentData: Stripe.Subscription) {
     const payment: Payment | null =
       await this.paymentRepository.findOneByStripeId(paymentData.id);
-    if (!payment && paymentData.status === 'active') {
-      const stripeCustomerId: string =
-        typeof paymentData.customer === 'string'
-          ? paymentData.customer
-          : paymentData.customer.id;
+    if (!payment) {
+      const stripeCustomerId: string = paymentData.customer.toString();
       const user: User =
         await this.userService.findByStripeId(stripeCustomerId);
+      const isAvalidateStatus: boolean = Object.keys(
+        SubscriptionStatus,
+      ).includes(paymentData.status.toUpperCase());
+      let statusEnum: SubscriptionStatus;
+      if (isAvalidateStatus) {
+        const statusString: string =
+          paymentData.status.toUpperCase() as keyof typeof SubscriptionStatus;
+        statusEnum = SubscriptionStatus[statusString];
+      } else {
+        statusEnum = SubscriptionStatus.UNEXPECTED;
+      }
       const createPaymentData: CreatePaymentDto = {
-        isActive: true,
+        status: statusEnum,
         stripeSubscriptionId: paymentData.id,
         user,
         currentPeriodStart: new Date(paymentData.current_period_start * 1000),
         currentPeriodEnd: new Date(paymentData.current_period_end * 1000),
       };
       await this.paymentRepository.create(createPaymentData);
-      await this.userService.updateSubscriptionType(user.id);
-    } else if (payment) {
-      const newStatus: boolean = paymentData.status !== 'active' ? false : true;
-      await this.paymentRepository.update(payment.id, { isActive: newStatus });
-      if (!newStatus) {
-        const stripeCustomerId: string =
-          typeof paymentData.customer === 'string'
-            ? paymentData.customer
-            : paymentData.customer.id;
-        const user: User =
-          await this.userService.findByStripeId(stripeCustomerId);
-        this.userService.downgradeSubscriptionType(user.id);
-      }
     }
   }
+
+  // async updatePayment(paymentData: Stripe.Subscription, previousData) {
+  //   const payment: Payment | null =
+  //     await this.paymentRepository.findOneByStripeId(paymentData.id);
+
+  //   if (payment)
+  //     if (!payment && paymentData.status === 'active') {
+  //       const stripeCustomerId: string =
+  //         typeof paymentData.customer === 'string'
+  //           ? paymentData.customer
+  //           : paymentData.customer.id;
+  //       const user: User =
+  //         await this.userService.findByStripeId(stripeCustomerId);
+  //       const createPaymentData: CreatePaymentDto = {
+  //         isActive: true,
+  //         stripeSubscriptionId: paymentData.id,
+  //         user,
+  //         currentPeriodStart: new Date(paymentData.current_period_start * 1000),
+  //         currentPeriodEnd: new Date(paymentData.current_period_end * 1000),
+  //       };
+  //       await this.paymentRepository.create(createPaymentData);
+  //       await this.userService.updateSubscriptionType(user.id);
+  //     } else if (payment) {
+  //       const newStatus: boolean =
+  //         paymentData.status !== 'active' ? false : true;
+  //       await this.paymentRepository.update(payment.id, {
+  //         isActive: newStatus,
+  //       });
+  //       if (!newStatus) {
+  //         const stripeCustomerId: string =
+  //           typeof paymentData.customer === 'string'
+  //             ? paymentData.customer
+  //             : paymentData.customer.id;
+  //         const user: User =
+  //           await this.userService.findByStripeId(stripeCustomerId);
+  //         this.userService.downgradeSubscriptionType(user.id);
+  //       }
+  //     }
+  // }
 
   async subscriptiondowngrade(paymentData: Stripe.Subscription) {
     if (!paymentData.id) return;
@@ -117,7 +175,7 @@ export class PaymentsService {
     );
     if (!payment) return;
     await this.paymentRepository.update(payment.id, {
-      isActive: false,
+      status: SubscriptionStatus.CANCELED,
       canceled_at: new Date(),
     });
     const consumerId: string = paymentData.customer.toString();
@@ -127,9 +185,24 @@ export class PaymentsService {
 
   async handleSubscriptionInvoicePaid(invoiceObject: Stripe.Invoice) {
     if (invoiceObject.subscription) {
-      const subscriptionId: string = invoiceObject.subscription.toString();
-      const subscriptionData =
-        this.stripeService.getSuscriptionData(subscriptionId);
+      const subscriptionStripeId: string =
+        invoiceObject.subscription.toString();
+      const subscriptionStripeData: Stripe.Subscription =
+        await this.stripeService.getSuscriptionData(subscriptionStripeId);
+      const payment: Payment | null =
+        await this.paymentRepository.findOneByStripeId(subscriptionStripeId);
+      if (payment) {
+        const updateData: UpdatePaymentDto = {
+          status: SubscriptionStatus.ACTIVE,
+          currentPeriodStart: new Date(
+            subscriptionStripeData.current_period_start * 1000,
+          ),
+          currentPeriodEnd: new Date(
+            subscriptionStripeData.current_period_end * 1000,
+          ),
+        };
+        await this.paymentRepository.update(payment.id, updateData);
+      }
     }
   }
 }

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -101,9 +101,9 @@ export class PaymentsService {
   }
 
   async registerPayment(paymentData: Stripe.Subscription) {
-    const payment: Payment | null =
+    const localRegisterPayment: Payment | null =
       await this.paymentRepository.findOneByStripeId(paymentData.id);
-    if (!payment) {
+    if (!localRegisterPayment) {
       const stripeCustomerId: string = paymentData.customer.toString();
       const user: User =
         await this.userService.findByStripeId(stripeCustomerId);
@@ -130,12 +130,11 @@ export class PaymentsService {
   }
 
   async updatePayment(paymentData: Stripe.Subscription) {
-    console.log(paymentData);
     const payment: Payment | null =
       await this.paymentRepository.findOneByStripeId(paymentData.id);
-    console.log(payment);
-    if (!payment) return;
-    if (payment) {
+    if (!payment) {
+      await this.registerPayment(paymentData);
+    } else if (payment) {
       const stripeCustomerId: string = paymentData.customer.toString();
       const user: User =
         await this.userService.findByStripeId(stripeCustomerId);

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -132,7 +132,7 @@ export class PaymentsService {
   async updatePayment(paymentData: Stripe.Subscription) {
     const payment: Payment | null =
       await this.paymentRepository.findOneByStripeId(paymentData.id);
-
+    console.log(payment);
     if (!payment) return;
     if (payment) {
       const stripeCustomerId: string = paymentData.customer.toString();

--- a/src/modules/stripe/stripe.controller.ts
+++ b/src/modules/stripe/stripe.controller.ts
@@ -5,27 +5,27 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
-import { StripeService } from './stripe.service';
 import Stripe from 'stripe';
 import { PaymentsService } from '../payments/payments.service';
 import { StripeWebhookGuard } from './guards/stripe.guard';
 
 @Controller('stripe')
 export class StripeController {
-  constructor(
-    // private readonly stripeService: StripeService,
-    private readonly paymentService: PaymentsService,
-  ) {}
+  constructor(private readonly paymentService: PaymentsService) {}
 
   @UseGuards(StripeWebhookGuard)
   @Post('webhook')
   async handleWebhook(@Req() req: RawBodyRequest<Request>) {
     const event = req['stripeEvent'] as Stripe.Event;
     switch (event.type) {
-      case 'customer.subscription.updated': {
+      case 'customer.subscription.created': {
         await this.paymentService.registerPayment(event.data.object);
         break;
       }
+      // case 'customer.subscription.updated': {
+      //   await this.paymentService.updatePayment(event.data.object, event.data);
+      //   break;
+      // }
       case 'customer.subscription.deleted': {
         await this.paymentService.subscriptiondowngrade(event.data.object);
         break;
@@ -36,6 +36,29 @@ export class StripeController {
         );
         break;
       }
+      // case 'customer.subscription.created': {
+      //   const subscription = event.data.object as Stripe.Subscription;
+
+      //   // Verificar si ya existe en tu DB (idempotencia)
+      //   const exists = await this.subscriptionRepo.findOneBy({
+      //     stripeSubscriptionId: subscription.id
+      //   });
+
+      //   if (!exists) {
+      //     await this.subscriptionRepo.save({
+      //       stripeSubscriptionId: subscription.id,
+      //       status: subscription.status,
+      //       user: await this.getUserFromCustomerId(subscription.customer),
+      //       currentPeriodEnd: new Date(subscription.current_period_end * 1000),
+      //     });
+
+      //     // Enviar email de bienvenida
+      //     this.emailService.sendSubscriptionConfirmation(
+      //       subscription.customer.toString()
+      //     );
+      //   }
+      //   break;
+      // }
       default: {
         console.log(`Evento del tipo ${event.type}, no manejado`);
       }

--- a/src/modules/stripe/stripe.controller.ts
+++ b/src/modules/stripe/stripe.controller.ts
@@ -22,10 +22,10 @@ export class StripeController {
         await this.paymentService.registerPayment(event.data.object);
         break;
       }
-      // case 'customer.subscription.updated': {
-      //   await this.paymentService.updatePayment(event.data.object, event.data);
-      //   break;
-      // }
+      case 'customer.subscription.updated': {
+        await this.paymentService.updatePayment(event.data.object);
+        break;
+      }
       case 'customer.subscription.deleted': {
         await this.paymentService.subscriptiondowngrade(event.data.object);
         break;


### PR DESCRIPTION
Se agregó la funcionalidad para que un usuario logeado como administrador pueda obtener todos los registros de los pagos, ordenado por fecha y paginados
Se cambió la lógica para que se guarden todos los pagos, incluso los que están pendientes de pago