### PR TITLE
update: post status create and update

### DIFF
--- a/src/modules/post/entities/post.entity.ts
+++ b/src/modules/post/entities/post.entity.ts
@@ -38,7 +38,7 @@ export class Post {
   @Column({
     type: 'enum',
     enum: PostStatus,
-    default: PostStatus.PENDING,
+    default: PostStatus.APPROVED,
   })
   status: PostStatus;
 

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -127,7 +127,7 @@ export class PostRepository {
     updatePostDto: UpdatePostDto,
   ): Promise<Post> {
     this.postRepository.merge(existingPost, updatePostDto);
-    existingPost.status = PostStatus.PENDING;
+    existingPost.status = PostStatus.APPROVED;
     return this.postRepository.save(existingPost);
   }
 


### PR DESCRIPTION
Se cambió el status por defecto de una publicación recién creada para que esté aprobada por defecto, además una publicación actualizada igualmente queda automáticamente en aprobado 